### PR TITLE
Added shutdown in order to cleanup scheduler

### DIFF
--- a/src/main/java/se/grunka/fortuna/Fortuna.java
+++ b/src/main/java/se/grunka/fortuna/Fortuna.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 import se.grunka.fortuna.accumulator.Accumulator;
@@ -32,6 +33,7 @@ public class Fortuna extends Random {
     private final Generator generator;
     private final Pool[] pools;
     private final ReentrantLock lock = new ReentrantLock();
+    private final Accumulator accumulator;
 
     public static Fortuna createInstance() {
         Pool[] pools = new Pool[32];
@@ -55,12 +57,13 @@ public class Fortuna extends Random {
                 throw new Error("Interrupted while waiting for initialization", e);
             }
         }
-        return new Fortuna(new Generator(), pools);
+        return new Fortuna(new Generator(), pools, accumulator);
     }
 
-    private Fortuna(Generator generator, Pool[] pools) {
+    private Fortuna(Generator generator, Pool[] pools, Accumulator accumulator) {
         this.generator = generator;
         this.pools = pools;
+        this.accumulator = accumulator;
     }
 
     private byte[] randomData(int bytes) {
@@ -104,6 +107,14 @@ public class Fortuna extends Random {
     @Override
     public synchronized void setSeed(long seed) {
         // Does not do anything
+    }
+    
+    public void shutdown(long l, TimeUnit tu) throws InterruptedException {
+        accumulator.shutdown(l, tu);
+    }
+    
+    public void shutdown() throws InterruptedException {
+        shutdown(30, TimeUnit.SECONDS);
     }
 
 }

--- a/src/main/java/se/grunka/fortuna/accumulator/Accumulator.java
+++ b/src/main/java/se/grunka/fortuna/accumulator/Accumulator.java
@@ -37,5 +37,16 @@ public class Accumulator {
         eventContexts.put(sourceId, context);
         eventScheduler.schedule(0, TimeUnit.MILLISECONDS);
     }
-
+    
+    public void shutdown(long l, TimeUnit tu) throws InterruptedException {
+        scheduler.shutdown();
+        
+        if (!scheduler.awaitTermination(l, tu)) {
+            scheduler.shutdownNow();
+        }
+    }
+    
+    public void shutdown() throws InterruptedException {
+        shutdown(30, TimeUnit.SECONDS);
+    }
 }


### PR DESCRIPTION
Removing all references from a `Fortuna` instance won’t cease and release the executor inside `Accumulator`. This pull request proposes the addition of `shutdown` to `Fortuna` in order to shutdown correctly.