### PR TITLE
RandomDataBuffer asynchronously produces and buffers bytes

### DIFF
--- a/src/main/java/com/grunka/random/fortuna/RandomDataBuffer.java
+++ b/src/main/java/com/grunka/random/fortuna/RandomDataBuffer.java
@@ -1,19 +1,60 @@
 package com.grunka.random.fortuna;
 
+import java.nio.ByteBuffer;
+import java.util.concurrent.*;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 class RandomDataBuffer {
-    private static final int RANDOM_DATA_CHUNK_SIZE = 1024 * 1024;
-    private byte[] buffer = new byte[0];
+
+    private static final Logger LOG = Logger.getLogger(RandomDataBuffer.class.getName());
+    private static final int RANDOM_DATA_CHUNK_SIZE = 1024 * 100;
+
+    private ByteBuffer currentBuffer;
+    private ByteBuffer exhaustedBuffer;
+    private BlockingQueue<ByteBuffer> bufferQueue = new ArrayBlockingQueue<>(3);
+
+    private final Function<ByteBuffer, ByteBuffer> randomDataSupplier;
+    private final Future<?> producerFuture;
+    private boolean producing = true;
+
     private int remainingBits = 0;
 
-    synchronized int next(int bits, Function<Integer, byte[]> randomDataSupplier) {
+    RandomDataBuffer(final ScheduledExecutorService scheduledExecutorService, final Function<ByteBuffer, ByteBuffer> randomDataSupplier) {
+        this.randomDataSupplier = randomDataSupplier;
+        producerFuture = scheduledExecutorService.submit(() -> {
+            while (producing) {
+                try {
+                    ByteBuffer bufferToFill = exhaustedBuffer == null
+                        ? createNewBuffer()
+                        : exhaustedBuffer;
+                    bufferQueue.put(randomDataSupplier.apply(bufferToFill));
+                } catch (InterruptedException e) {
+                    LOG.log(Level.WARNING, "Problem putting filled buffer into queue.");
+                }
+            }
+        });
+        waitForQueueInitialization();
+    }
+
+    private void waitForQueueInitialization() {
+        while (bufferQueue.isEmpty()) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                throw new Error("Interrupted while waiting for initialization", e);
+            }
+        }
+    }
+
+    synchronized int next(int bits) {
         int result = 0;
         int bitsStillToTake = bits;
         while (bitsStillToTake > 0) {
             if (remainingBits == 0) {
-                buffer = randomDataSupplier.apply(RANDOM_DATA_CHUNK_SIZE);
-                remainingBits = buffer.length * 8;
+                currentBuffer = nextBuffer(currentBuffer);
+                remainingBits = currentBuffer.limit() * 8;
                 if (remainingBits <= 0) {
                     throw new IllegalStateException("Could not get more bits");
                 }
@@ -22,13 +63,34 @@ class RandomDataBuffer {
             if (remainingBitsInByte == 0) {
                 remainingBitsInByte = 8;
             }
-            int currentByte = buffer.length - (remainingBits / 8) - (remainingBitsInByte == 8 ? 0 : 1);
+            int currentByte = currentBuffer.limit() - (remainingBits / 8) - (remainingBitsInByte == 8 ? 0 : 1);
             int bitsToTakeNow = Math.min(bitsStillToTake, remainingBitsInByte);
-            result = (result << bitsToTakeNow) | (((buffer[currentByte] >>> (remainingBitsInByte - bitsToTakeNow)) & 0xff) & mask(bitsToTakeNow));
+            result = (result << bitsToTakeNow) | (((currentBuffer.get(currentByte) >>> (remainingBitsInByte - bitsToTakeNow)) & 0xff) & mask(bitsToTakeNow));
             remainingBits -= bitsToTakeNow;
             bitsStillToTake -= bitsToTakeNow;
         }
         return result;
+    }
+
+    private ByteBuffer nextBuffer(ByteBuffer previous) {
+        this.exhaustedBuffer = previous;
+        if (this.exhaustedBuffer == null) {
+            this.exhaustedBuffer = createNewBuffer();
+        }
+        if (this.bufferQueue.isEmpty()) {
+            return randomDataSupplier.apply(exhaustedBuffer);
+        } else {
+            return bufferQueue.poll();
+        }
+    }
+
+    void stopProducing() {
+        this.producing = false;
+        this.producerFuture.cancel(true);
+    }
+
+    private static ByteBuffer createNewBuffer() {
+        return ByteBuffer.allocateDirect(RANDOM_DATA_CHUNK_SIZE);
     }
 
     private int mask(int bits) {

--- a/src/test/java/com/grunka/random/fortuna/FortunaTest.java
+++ b/src/test/java/com/grunka/random/fortuna/FortunaTest.java
@@ -4,6 +4,9 @@ import org.apache.commons.math3.distribution.UniformRealDistribution;
 import org.apache.commons.math3.random.ISAACRandom;
 import org.apache.commons.math3.random.MersenneTwister;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -16,10 +19,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
 
 public class FortunaTest {
     @Test
@@ -34,14 +35,14 @@ public class FortunaTest {
 
     @Test
     public void shouldProduceEvenDistribution() {
-        int numbers = 1000;
+        int numbers = 1_000;
         SummaryStatistics fortunaNumbers = new SummaryStatistics();
         SummaryStatistics isaacNumbers = new SummaryStatistics();
         SummaryStatistics mersenneNumbers = new SummaryStatistics();
         Fortuna fortuna = Fortuna.createInstance();
         ISAACRandom isaacRandom = new ISAACRandom();
         MersenneTwister mersenneTwister = new MersenneTwister();
-        for (int i = 0; i < 10000000; i++) {
+        for (int i = 0; i < 10_000_000; i++) {
             fortunaNumbers.addValue(fortuna.nextInt(numbers));
             isaacNumbers.addValue(isaacRandom.nextInt(numbers));
             mersenneNumbers.addValue(mersenneTwister.nextInt(numbers));
@@ -141,7 +142,7 @@ public class FortunaTest {
 
         @Override
         public Future<?> submit(Runnable task) {
-            throw new UnsupportedOperationException();
+            return delegate.submit(task);
         }
 
         @Override

--- a/src/test/java/com/grunka/random/fortuna/RandomDataBufferTest.java
+++ b/src/test/java/com/grunka/random/fortuna/RandomDataBufferTest.java
@@ -1,42 +1,58 @@
 package com.grunka.random.fortuna;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 
 public class RandomDataBufferTest {
 
-    private RandomDataBuffer randomDataBuffer;
-    private Function<Integer, byte[]> dataSupplier;
+    private ScheduledExecutorService scheduledExecutorService;
 
     @Before
     public void setUp() {
-        randomDataBuffer = new RandomDataBuffer();
-        dataSupplier = (i) -> new byte[]{(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef, (byte) 0xfa, (byte) 0xce, (byte) 0xfe, (byte) 0xed};
+        scheduledExecutorService =
+            Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+    }
+
+    @After
+    public void tearDown() {
+        scheduledExecutorService.shutdown();
     }
 
     @Test
     public void testGettingBits() {
-        assertEquals("deadbeef", Integer.toHexString(randomDataBuffer.next(32, dataSupplier)));
-        assertEquals("f", Integer.toHexString(randomDataBuffer.next(4, dataSupplier)));
-        assertEquals("ac", Integer.toHexString(randomDataBuffer.next(8, dataSupplier)));
-        assertEquals("efee", Integer.toHexString(randomDataBuffer.next(16, dataSupplier)));
-        assertEquals("ddeadbee", Integer.toHexString(randomDataBuffer.next(32, dataSupplier)));
-        assertEquals("f", Integer.toHexString(randomDataBuffer.next(4, dataSupplier)));
+        Function<ByteBuffer, ByteBuffer> dataSupplier =
+            (i) -> ByteBuffer.wrap(new byte[]{(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef, (byte) 0xfa, (byte) 0xce, (byte) 0xfe, (byte) 0xed});
+        RandomDataBuffer randomDataBuffer =
+            new RandomDataBuffer(scheduledExecutorService, dataSupplier);
+        assertEquals("deadbeef", Integer.toHexString(randomDataBuffer.next(32)));
+        assertEquals("f", Integer.toHexString(randomDataBuffer.next(4)));
+        assertEquals("ac", Integer.toHexString(randomDataBuffer.next(8)));
+        assertEquals("efee", Integer.toHexString(randomDataBuffer.next(16)));
+        assertEquals("ddeadbee", Integer.toHexString(randomDataBuffer.next(32)));
+        assertEquals("f", Integer.toHexString(randomDataBuffer.next(4)));
 
         for (int i = 0; i < 32; i++) {
-            assertEquals("" + Integer.toBinaryString(0xfacefeed).charAt(i), Integer.toBinaryString(randomDataBuffer.next(1, dataSupplier)));
+            assertEquals("" + Integer.toBinaryString(0xfacefeed).charAt(i), Integer.toBinaryString(randomDataBuffer.next(1)));
         }
         for (int i = 0; i < 32; i++) {
-            assertEquals("" + Integer.toBinaryString(0xdeadbeef).charAt(i), Integer.toBinaryString(randomDataBuffer.next(1, dataSupplier)));
+            assertEquals("" + Integer.toBinaryString(0xdeadbeef).charAt(i), Integer.toBinaryString(randomDataBuffer.next(1)));
         }
     }
 
     @Test(expected = IllegalStateException.class)
     public void shouldFailIfNoDataIsProvided() {
-        randomDataBuffer.next(1, (i) -> new byte[0]);
+        Function<ByteBuffer, ByteBuffer> dataSupplier =
+                (i) -> ByteBuffer.wrap(new byte[0]);
+        RandomDataBuffer randomDataBuffer =
+            new RandomDataBuffer(scheduledExecutorService, dataSupplier);
+        randomDataBuffer.next(1);
     }
 }


### PR DESCRIPTION
... to prevent delays due to reseeding with the random number requesting thread. This drastically smoothes the runtime times when requesting random numbers. Additionally reduces total amount of buffered bytes by 50%.